### PR TITLE
Add additional supported architectures to metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for the PF1550 Power Management IC
 paragraph=This library allows the control and configuration of the PF1550 used on various Arduino boards.
 category=Device Control
 url=https://github.com/arduino-libraries/Arduino_PF1550
-architectures=mbed
+architectures=mbed,mbed_nicla,mbed_portenta


### PR DESCRIPTION
Previously, the library's metadata only specified compatibility with the `mbed` architecture. This is the architecture used by the "**[DEPRECATED - Please install standalone packages] Arduino Mbed OS Boards**" platform. As you might guess from the name, this platform is deprecated. Since it is clearly marked as such and has been so for some time, it is likely the majority of users have switched to the more specific "**Arduino Mbed OS \_\_\_ Boards**" platforms.

Since compatibility with those architectures was not specified in [the metadata](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata), the following impacts resulted on users who had one of the boards of the non-deprecated platforms selected:

### Incompatibility warning during compilation

A warning was displayed in the compilation output. For example

```
WARNING: library Arduino_PF1550-master claims to run on mbed architecture(s) and may be incompatible with your current board which runs on mbed_portenta architecture(s).
```

### Examples marked incompatible

The library's example sketches were placed under the **File > Examples > INCOMPATIBLE** menu of Arduino IDE 1.x (example categorization by compatibility [not implemented in Arduino IDE 2.x at this time](https://github.com/arduino/arduino-ide/issues/817)), and the equivalent in the [`arduino-cli lib examples`](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib_examples/) output.

### Suppression in library listings

The library was not listed in the [`arduino-cli lib list --fqbn`](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib_list/) output.