### PR TITLE
Allow software control of Buck/Boost SW1

### DIFF
--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -125,6 +125,27 @@ void PF1550::configLDO3(Ldo3Voltage const ldo_3_volt, bool const enable, bool co
   else                  _control.turnLDO3Off(Ldo3Mode::Sleep);
 }
 
+void PF1550::configSw1(Sw1Voltage      const sw1_volt,
+                       Sw1Voltage      const sw1_volt_standby,
+                       Sw1Voltage      const sw1_volt_sleep,
+                       Sw1CurrentLimit const sw1_current_limit,
+                       bool            const enable,
+                       bool            const enable_in_standby,
+                       bool            const enable_in_sleep)
+{
+  _control.setSw1Voltage       (sw1_volt);
+  _control.setSw1VoltageStandby(sw1_volt_standby);
+  _control.setSw1VoltageSleep  (sw1_volt_sleep);
+  _control.setSw1CurrentLimit  (sw1_current_limit);
+
+  if(enable)            _control.turnSw1On (Sw1Mode::Normal);
+  else                  _control.turnSw1Off(Sw1Mode::Normal);
+  if(enable_in_standby) _control.turnSw1On (Sw1Mode::Standby);
+  else                  _control.turnSw1Off(Sw1Mode::Standby);
+  if(enable_in_sleep)   _control.turnSw1On (Sw1Mode::Sleep);
+  else                  _control.turnSw1Off(Sw1Mode::Sleep);
+}
+
 void PF1550::configSw2(Sw2Voltage      const sw2_volt,
                        Sw2Voltage      const sw2_volt_standby,
                        Sw2Voltage      const sw2_volt_sleep,

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -61,6 +61,14 @@ public:
   void configLDO2(Ldo2Voltage const ldo_2_volt, bool const enable, bool const enable_in_standby, bool const enable_in_sleep);
   void configLDO3(Ldo3Voltage const ldo_3_volt, bool const enable, bool const enable_in_standby, bool const enable_in_sleep);
 
+  void configSw1(Sw1Voltage      const sw1_volt,
+                 Sw1Voltage      const sw1_volt_standby,
+                 Sw1Voltage      const sw1_volt_sleep,
+                 Sw1CurrentLimit const sw1_current_limit,
+                 bool            const enable,
+                 bool            const enable_in_standby,
+                 bool            const enable_in_sleep);
+
   void configSw2(Sw2Voltage      const sw2_volt,
                  Sw2Voltage      const sw2_volt_standby,
                  Sw2Voltage      const sw2_volt_sleep,

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -67,7 +67,7 @@ public:
                  Sw1CurrentLimit const sw1_current_limit,
                  bool            const enable,
                  bool            const enable_in_standby,
-                 bool            const enable_in_sleep);
+                 bool            const enable_in_sleep) __attribute__ ((error("Erroneus usage of this API can cause board damage.")));
 
   void configSw2(Sw2Voltage      const sw2_volt,
                  Sw2Voltage      const sw2_volt_standby,

--- a/src/PF1550/PF1550_Control.cpp
+++ b/src/PF1550/PF1550_Control.cpp
@@ -118,6 +118,41 @@ void PF1550_Control::turnLDO3Off(Ldo3Mode const mode)
   _io.clrBit(Register::PMIC_LDO3_CTRL, static_cast<uint8_t>(mode));
 }
 
+void PF1550_Control::setSw1Voltage(Sw1Voltage const sw1_volt)
+{
+  writeReg(Register::PMIC_SW1_VOLT, static_cast<uint8_t>(sw1_volt));
+}
+
+void PF1550_Control::setSw1VoltageStandby(Sw1Voltage const sw1_volt_standby)
+{
+  writeReg(Register::PMIC_SW1_STBY_VOLT, static_cast<uint8_t>(sw1_volt_standby));
+}
+
+void PF1550_Control::setSw1VoltageSleep(Sw1Voltage const sw1_volt_sleep)
+{
+  writeReg(Register::PMIC_SW1_SLP_VOLT, static_cast<uint8_t>(sw1_volt_sleep));
+}
+
+void PF1550_Control::setSw1CurrentLimit(Sw1CurrentLimit const sw1_current_limit)
+{
+  uint8_t sw1_ctrl1_reg;
+  _io.readRegister(Register::PMIC_SW1_CTRL1, &sw1_ctrl1_reg);
+  sw1_ctrl1_reg &= ~REG_SW1_CTRL1_SW1_ILIM_mask;
+  sw1_ctrl1_reg |= static_cast<uint8_t>(sw1_current_limit);
+
+  writeReg(Register::PMIC_SW1_CTRL1, sw1_ctrl1_reg);
+}
+
+void PF1550_Control::turnSw1On(Sw1Mode const mode)
+{
+  _io.setBit(Register::PMIC_SW1_CTRL, static_cast<uint8_t>(mode));
+}
+
+void PF1550_Control::turnSw1Off(Sw1Mode const mode)
+{
+  _io.clrBit(Register::PMIC_SW1_CTRL, static_cast<uint8_t>(mode));
+}
+
 void PF1550_Control::setSw2Voltage(Sw2Voltage const sw2_volt)
 {
   writeReg(Register::PMIC_SW2_VOLT, static_cast<uint8_t>(sw2_volt));

--- a/src/PF1550/PF1550_Control.h
+++ b/src/PF1550/PF1550_Control.h
@@ -65,6 +65,14 @@ public:
   void turnLDO3On       (Ldo3Mode    const mode);
   void turnLDO3Off      (Ldo3Mode    const mode);
 
+  /* SW1 Configuration ********************************************************/
+  void setSw1Voltage       (Sw1Voltage      const sw1_volt);
+  void setSw1VoltageStandby(Sw1Voltage      const sw1_volt_standby);
+  void setSw1VoltageSleep  (Sw1Voltage      const sw1_volt_sleep);
+  void setSw1CurrentLimit  (Sw1CurrentLimit const sw1_current_limit);
+  void turnSw1On           (Sw1Mode         const mode);
+  void turnSw1Off          (Sw1Mode         const mode);
+
   /* SW2 Configuration ********************************************************/
   void setSw2Voltage       (Sw2Voltage      const sw2_volt);
   void setSw2VoltageStandby(Sw2Voltage      const sw2_volt_standby);

--- a/src/PF1550/PF1550_Defines.h
+++ b/src/PF1550/PF1550_Defines.h
@@ -33,6 +33,14 @@
 #define REG_INT_CATEGORY_TEMP_INT_bp            (6)
 #define REG_INT_CATEGORY_MISC_INT_bp            (7)
 
+/* SW1_CTRL1 ******************************************************************/
+#define REG_SW1_CTRL1_SW1_ILIM_mask             (0x03)
+
+/* SW1_CTRL *******************************************************************/
+#define REG_SW1_CTRL_SW1_EN_bp                  (0)
+#define REG_SW1_CTRL_SW1_STBY_EN_bp             (1)
+#define REG_SW1_CTRL_SW1_OMODE_bp               (2)
+
 /* SW2_CTRL *******************************************************************/
 #define REG_SW2_CTRL_SW2_EN_bp                  (0)
 #define REG_SW2_CTRL_SW2_STBY_EN_bp             (1)

--- a/src/PF1550/PF1550_Types.h
+++ b/src/PF1550/PF1550_Types.h
@@ -219,6 +219,37 @@ enum class IInputCurrentLimit : uint8_t
   I_1500_mA  = (0x14 << 3),
 };
 
+enum class Sw1Voltage : uint8_t
+{
+  /* Output voltage with DVS disabled (OTP_SWx_DVS_SEL = 1).
+   * This is necessary because otherwise we won't reach the
+   * voltages required by Envie H747/C33 which is 3V1/3V3 for SW1.
+   */
+  V_1_10 = 0x00,
+  V_1_20 = 0x01,
+  V_1_35 = 0x02,
+  V_1_50 = 0x03,
+  V_1_80 = 0x04,
+  V_2_50 = 0x05,
+  V_3_00 = 0x06,
+  V_3_30 = 0x07,
+};
+
+enum class Sw1CurrentLimit : uint8_t
+{
+  I_1_0_A = 0x00,
+  I_1_2_A = 0x01,
+  I_1_5_A = 0x02,
+  I_2_0_A = 0x03,
+};
+
+enum class Sw1Mode : uint8_t
+{
+  Normal  = REG_SW1_CTRL_SW1_EN_bp,
+  Standby = REG_SW1_CTRL_SW1_STBY_EN_bp,
+  Sleep   = REG_SW1_CTRL_SW1_OMODE_bp,
+};
+
 enum class Sw2Voltage : uint8_t
 {
   /* Output voltage with DVS disabled (OTP_SWx_DVS_SEL = 1).


### PR DESCRIPTION
Note: SW3 can not be run-time software-controller, values are loaded at startup from fuses, regs are RO only.

Also see [datasheet](https://www.nxp.com/docs/en/data-sheet/PF1550DS.pdf), table 122.