### PR TITLE
Fix Portenta C33 job configuration in "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -52,10 +52,9 @@ jobs:
             platforms: |
               - name: arduino:mbed_portenta
             sketch-paths:
-          - fqbn: arduino:renesas:portenta_h33
+          - fqbn: arduino:renesas_portenta:portenta_c33
             platforms: |
-              - name: arduino:renesas
-                source-url: https://downloads.arduino.cc/packages/package_renesas_index.json
+              - name: arduino:renesas_portenta
             sketch-paths: |
               - examples/C33-Low-Power
 


### PR DESCRIPTION
Previously the "Compile Examples" GitHub Actions workflow was configured to install the boards platform dependency of the [**Portenta C33** board](https://docs.arduino.cc/hardware/portenta-c33) via a package index published for the purposes of beta testing during the initial development of [the "**Arduino Renesas Portenta Boards**" platform](https://github.com/arduino/ArduinoCore-renesas). That package index was later deleted, which caused the job to fail:

```text
Downloading index: package_renesas_index.json 0 B / ?    0.00%
Downloading index: package_renesas_index.json Server responded with: 404 Not Found
Some indexes could not be updated.
```

The "**Arduino Renesas Portenta Boards**" platform is now part of [the primary package index](https://downloads.arduino.cc/packages/package_index.json) so the job can be restored to a working state. Since that time, the board ID for the **Portenta C33** board was changed to `portenta_c33` (https://github.com/arduino/ArduinoCore-renesas/commit/6d3187becc01398cc08bc947ccd60afcd6da5da8) so the FQBN of the board is also updated here.

---

The job still fails:

```
  /home/runner/Arduino/libraries/Arduino_PF1550/src/PF1550.cpp:192:3: error: #error "No IO class defined for this board."
   # error "No IO class defined for this board."
     ^~~~~
```

but this time it is due to a legitimate bug in the library: the board identification macro for the **Portenta C33** was changed in the platform from `ARDUINO_PORTENTA_H33` to `ARDUINO_PORTENTA_C33`(https://github.com/arduino/ArduinoCore-renesas/commit/ad5a50a52342b1ad0912bddb97cd812fd3098b40).