### PR TITLE
Fix: board was renamed to ARDUINO_PORTENTA_C33 which subsequently broke this library.

### DIFF
--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -182,7 +182,7 @@ void PF1550::configCharger(IFastCharge        const i_fast_charge,
    EXTERN DEFINITION
  ******************************************************************************/
 
-#if defined(ARDUINO_PORTENTA_H33)
+#if defined(ARDUINO_PORTENTA_C33)
 static PF1550_IO_C33          io(&Wire3, PF1550_I2C_DEFAULT_ADDR);
 #elif defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
 static PF1550_IO_Portenta_H7  io(&Wire1, PF1550_I2C_DEFAULT_ADDR);

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -70,7 +70,7 @@ public:
                  bool            const enable_in_sleep)
 #if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
                  __attribute__ ((error("Erroneous usage of this API can cause board damage.")))
-#elif defined(ARDUINO_PORTENTA_H33)
+#elif defined(ARDUINO_PORTENTA_C33)
                 __attribute__ ((warning("Using this API you can turn off ESP32 (WiFi), SE051 (Crypto) and Ethernet PHY. Proceed with caution.")))
 #endif
                  ;


### PR DESCRIPTION
Detected by @per1234 over in #15.