### PR TITLE
Add umbrella header file that matches lib name

### DIFF
--- a/examples/BasicUsage/BasicUsage.ino
+++ b/examples/BasicUsage/BasicUsage.ino
@@ -2,7 +2,7 @@
  * Demonstrate basic library usage.
  */
 
-#include <Arduino_PMIC.h>
+#include <Arduino_PF1550.h>
 
 void setup() {
   PMIC.begin();

--- a/examples/C33-Low-Power/C33-Low-Power.ino
+++ b/examples/C33-Low-Power/C33-Low-Power.ino
@@ -2,7 +2,7 @@
  * Test low power capability of Portenta C33.
  */
 
-#include <Arduino_PMIC.h>
+#include <Arduino_PF1550.h>
 
 #include <Wire.h>
 

--- a/examples/ReadWriteRegs/ReadWriteRegs.ino
+++ b/examples/ReadWriteRegs/ReadWriteRegs.ino
@@ -2,7 +2,7 @@
  * Read and write some registers from the PF1550 PMIC.
  */
 
-#include <Arduino_PMIC.h>
+#include <Arduino_PF1550.h>
 
 //#define Serial Serial1
 

--- a/src/Arduino_PF1550.h
+++ b/src/Arduino_PF1550.h
@@ -1,0 +1,28 @@
+/*
+  Copyright (c) 2019 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef ARDUINO_PF1550_H
+#define ARDUINO_PF1550_H
+
+/******************************************************************************
+   INCLUDE
+ ******************************************************************************/
+
+#include "PF1550.h"
+
+#endif /* ARDUINO_PF1550_H */


### PR DESCRIPTION
Solves #3 by adding an umbrella header that matches the library name as desired by Arduino Lint.
The old header is left in place for the time being to ensure backwards compatibility. To avoid clashes in sketches using this library, they can now refer to this new header file.