### PR TITLE
Added modifications to make this library compatible with the Arduino_PowerManagement library

### DIFF
--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -178,6 +178,10 @@ void PF1550::configCharger(IFastCharge        const i_fast_charge,
   _control.setInputCurrentLimit (i_input_current_limit);
 }
 
+PF1550_Control * PF1550::getControlPointer(){
+  return &this -> _control;
+}
+
 /******************************************************************************
    EXTERN DEFINITION
  ******************************************************************************/

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -95,6 +95,8 @@ public:
   /* Actual PMIC event ISR handler with access to member variables */
   inline void onPMICEvent() { _control.onPMICEvent(); }
 
+  PF1550_Control * getControlPointer();
+
 
 private:
   PF1550_Control _control;

--- a/src/PF1550/PF1550_Control.cpp
+++ b/src/PF1550/PF1550_Control.cpp
@@ -56,6 +56,11 @@ void PF1550_Control::setBit(Register const reg, uint8_t const bit_pos)
   _io.setBit(reg, bit_pos);
 }
 
+void PF1550_Control::clrBit(Register const reg, uint8_t const bit_pos)
+{
+  _io.clrBit(reg, bit_pos);
+}
+
 void PF1550_Control::writeReg(Register const reg_addr, uint8_t const val)
 {
   if (_debug) {

--- a/src/PF1550/PF1550_Control.h
+++ b/src/PF1550/PF1550_Control.h
@@ -49,6 +49,7 @@ public:
   void debug(Stream& stream);
 
   void setBit  (Register const reg, uint8_t const bit_pos);
+  void clrBit(Register const reg, uint8_t const bit_pos);
   void writeReg(Register const reg_addr, uint8_t const val);
   void readReg (Register const reg_addr, uint8_t * data);
 


### PR DESCRIPTION
The Arduino_PowerManagement library makes heavy use of the PF1550_Control class for a more granular control over different parts of the PMIC, my modifications add a pointer to the PF1550_Control class, and a add a clrBit() method in the Control class for convenience. 