### PR TITLE
Rename getter

### DIFF
--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -178,7 +178,7 @@ void PF1550::configCharger(IFastCharge        const i_fast_charge,
   _control.setInputCurrentLimit (i_input_current_limit);
 }
 
-PF1550_Control * PF1550::getControlPointer(){
+PF1550_Control* PF1550::getControl(){
   return &this -> _control;
 }
 

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -95,7 +95,7 @@ public:
   /* Actual PMIC event ISR handler with access to member variables */
   inline void onPMICEvent() { _control.onPMICEvent(); }
 
-  PF1550_Control * getControlPointer();
+  PF1550_Control* getControl();
 
 
 private:


### PR DESCRIPTION
This PR renames the recently added getter ~and bumps the version number so we can make a release.
This is necessary as another library that's in the works depends on having the getter available.~