### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_PF1550
 version=0.3.0
 author=Alexander Entinger <a.entinger@arduino.cc>
-maintainer=Alexander Entinger <a.entinger@arduino.cc>
+maintainer=Arduino <info@arduino.cc>
 sentence=Arduino library for the PF1550 Power Management IC
 paragraph=This library allows the control and configuration of the PF1550 used on various Arduino boards.
 category=Device Control


### PR DESCRIPTION
Maintainer is changed from `Alexander Entinger <a.entinger@arduino.cc>` to `Arduino <info@arduino.cc>` within the `library.properties` file. 