### PR TITLE
fix: warning no return statement in function returning non-void

### DIFF
--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -43,12 +43,12 @@ PF1550::PF1550(PF1550_IO & io)
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-int PF1550::begin()
+void PF1550::begin()
 {
   if (_debug) {
     _debug->println("PF1550 begin");
   }
-  return _control.begin();
+  _control.begin();
 }
 
 void PF1550::debug(Stream& stream)

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -49,7 +49,7 @@ public:
 
   PF1550(PF1550_IO & io);
 
-  int begin();
+  void begin();
 
   void debug(Stream& stream);
 

--- a/src/PF1550/PF1550_Control.cpp
+++ b/src/PF1550/PF1550_Control.cpp
@@ -40,9 +40,9 @@ PF1550_Control::PF1550_Control(PF1550_IO & io)
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-int PF1550_Control::begin()
+void PF1550_Control::begin()
 {
-  return _io.begin();
+  _io.begin();
 }
 
 void PF1550_Control::debug(Stream& stream)

--- a/src/PF1550/PF1550_Control.h
+++ b/src/PF1550/PF1550_Control.h
@@ -45,7 +45,7 @@ public:
   PF1550_Control(PF1550_IO & io);
 
 
-  int begin();
+  void begin();
   void debug(Stream& stream);
 
   void setBit  (Register const reg, uint8_t const bit_pos);

--- a/src/PF1550/PF1550_IO.cpp
+++ b/src/PF1550/PF1550_IO.cpp
@@ -41,11 +41,11 @@ PF1550_IO::PF1550_IO(arduino::HardwareI2C * wire, uint8_t const i2c_addr)
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-int PF1550_IO::begin()
+void PF1550_IO::begin()
 {
   _wire->begin();
   _wire->setClock(100000);
-  return derived_begin();
+  derived_begin();
 }
 
 void PF1550_IO::readRegister(Register const reg_addr, uint8_t * data)

--- a/src/PF1550/PF1550_IO.h
+++ b/src/PF1550/PF1550_IO.h
@@ -50,7 +50,7 @@ public:
   void debug (Stream& stream) { _debug = &stream; }
 
 
-  int begin();
+  void begin();
 
   void readRegister (Register const reg_addr, uint8_t * data);
   void writeRegister(Register const reg_addr, uint8_t const data);
@@ -60,7 +60,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() = 0;
+  virtual void derived_begin() = 0;
 
 private:
   arduino::HardwareI2C * _wire;

--- a/src/PF1550/PF1550_IO_C33.h
+++ b/src/PF1550/PF1550_IO_C33.h
@@ -39,7 +39,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() override
+  virtual void derived_begin() override
   {
     /* Enable LED. */
     setBit(Register::CHARGER_LED_PWM, REG_LED_PWM_LED_EN_bp);

--- a/src/PF1550/PF1550_IO_Nicla_Vision.h
+++ b/src/PF1550/PF1550_IO_Nicla_Vision.h
@@ -37,7 +37,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() override { }
+  virtual void derived_begin() override { }
 };
 
 #endif /* PF1550_IO_NICLA_VISION_H_ */

--- a/src/PF1550/PF1550_IO_Portenta_H7.h
+++ b/src/PF1550/PF1550_IO_Portenta_H7.h
@@ -37,7 +37,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() override { }
+  virtual void derived_begin() override { }
 };
 
 #endif /* PF1550_IO_ENVIEH747_H_ */


### PR DESCRIPTION
Fixed the warning below by returning `void` instead of `int` because none of the related functions return anything.

```
In file included from Arduino_PF1550/src/PF1550.cpp:28:0:
Arduino_PF1550/src/PF1550/PF1550_IO_Portenta_H7.h: In member function 'virtual int PF1550_IO_Portenta_H7::derived_begin()':
Arduino_PF1550/src/PF1550/PF1550_IO_Portenta_H7.h:40:42: warning: no return statement in function returning non-void [-Wreturn-type]
   virtual int derived_begin() override { }
                                          ^
```