### PR TITLE
Add begin() guard

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for the PF1550 Power Management IC
 paragraph=This library allows the control and configuration of the PF1550 used on various Arduino boards.
 category=Device Control
 url=https://github.com/arduino-libraries/Arduino_PF1550
-architectures=mbed,mbed_nicla,mbed_portenta,renesas
+architectures=mbed,mbed_nicla,mbed_portenta,renesas,renesas_portenta

--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -33,8 +33,9 @@
  ******************************************************************************/
 
 PF1550::PF1550(PF1550_IO & io)
-: _control(io),
-  _debug(NULL)
+: _control(io)
+, _initialized(false)
+, _debug(NULL)
 {
 
 }

--- a/src/PF1550.cpp
+++ b/src/PF1550.cpp
@@ -45,10 +45,19 @@ PF1550::PF1550(PF1550_IO & io)
 
 int PF1550::begin()
 {
+  if(_initialized) {
+    return 0;
+  }
+
   if (_debug) {
     _debug->println("PF1550 begin");
   }
-  return _control.begin();
+  int returnCode = _control.begin();
+  
+  if (returnCode == 0) {
+    _initialized = true;
+  }
+  return returnCode;
 }
 
 void PF1550::debug(Stream& stream)

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -100,7 +100,7 @@ public:
 
 private:
   PF1550_Control _control;
-  volatile bool _initialized;
+  bool _initialized;
   Stream* _debug;
 };
 

--- a/src/PF1550.h
+++ b/src/PF1550.h
@@ -100,6 +100,7 @@ public:
 
 private:
   PF1550_Control _control;
+  volatile bool _initialized;
   Stream* _debug;
 };
 

--- a/src/PF1550/PF1550_IO.cpp
+++ b/src/PF1550/PF1550_IO.cpp
@@ -52,7 +52,14 @@ void PF1550_IO::readRegister(Register const reg_addr, uint8_t * data)
 {
   _wire->beginTransmission(_i2c_addr);
   _wire->write(static_cast<uint8_t>(reg_addr));
-  _wire->endTransmission(false); /* No Stop. */
+  
+  /* No Stop. */
+  if(_wire->endTransmission(false) != 0) {
+    if (_debug) {
+      _debug->println("PF1550_IO::readRegister: endTransmission failed");
+    }
+    return;
+  }
 
   _wire->requestFrom(_i2c_addr, 1, true);
   while (_wire->available() < 1) { }

--- a/src/PF1550/PF1550_IO.cpp
+++ b/src/PF1550/PF1550_IO.cpp
@@ -84,6 +84,14 @@ void PF1550_IO::setBit(Register const reg, uint8_t const bit_pos)
   writeRegister(reg, reg_val);
 }
 
+uint8_t PF1550_IO::getBit(Register const reg, uint8_t const bit_pos)
+{
+  assert(bit_pos < 8);
+  uint8_t reg_val;
+  readRegister(reg, &reg_val);
+  return (reg_val >> bit_pos) & 1;
+}
+
 void PF1550_IO::clrBit(Register const reg, uint8_t const bit_pos)
 {
   assert(bit_pos < 8);

--- a/src/PF1550/PF1550_IO.h
+++ b/src/PF1550/PF1550_IO.h
@@ -56,6 +56,7 @@ public:
   void writeRegister(Register const reg_addr, uint8_t const data);
 
   void setBit(Register const reg, uint8_t const bit_pos);
+  uint8_t getBit(Register const reg, uint8_t const bit_pos);
   void clrBit(Register const reg, uint8_t const bit_pos);
 
 

--- a/src/PF1550/PF1550_IO_C33.h
+++ b/src/PF1550/PF1550_IO_C33.h
@@ -45,6 +45,15 @@ protected:
     setBit(Register::CHARGER_LED_PWM, REG_LED_PWM_LED_EN_bp);
     /* Allow LED control by software. */
     setBit(Register::CHARGER_LED_CNFG, REG_LED_CNFG_LEDOVRD_bp);
+
+    if(getBit(Register::CHARGER_LED_PWM, REG_LED_PWM_LED_EN_bp) == 0){
+      return -1;
+    }
+
+    if(getBit(Register::CHARGER_LED_CNFG, REG_LED_CNFG_LEDOVRD_bp) == 0){
+      return -1;
+    }
+    return 0;
   }
 
 };

--- a/src/PF1550/PF1550_IO_Nicla_Vision.h
+++ b/src/PF1550/PF1550_IO_Nicla_Vision.h
@@ -37,7 +37,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() override { }
+  virtual int derived_begin() override { return 0; }
 };
 
 #endif /* PF1550_IO_NICLA_VISION_H_ */

--- a/src/PF1550/PF1550_IO_Portenta_H7.h
+++ b/src/PF1550/PF1550_IO_Portenta_H7.h
@@ -37,7 +37,7 @@ public:
 
 
 protected:
-  virtual int derived_begin() override { }
+  virtual int derived_begin() override { return 0;}
 };
 
 #endif /* PF1550_IO_ENVIEH747_H_ */


### PR DESCRIPTION
This PR adds a guard to make `begin()` idempotent. Along with that the PR fixes a few warnings and adds additional error handling.